### PR TITLE
fix(Fetching): Change referer classname

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function ghPinnedRepos (username) {
   return got(`https://github.com/${username}`)
     .then(res => res.body)
     .then(cheerio.load)
-    .then(cash => cash('.pinned-repo-item.public'))
+    .then(cash => cash('.pinned-item-list-item.public'))
     .then(repos => repos.map(getHref).get())
 }
 


### PR DESCRIPTION
Hi, 

Thanks you for your module, but there are a little problem... Github has recently change classname of Pinned Items into `pinned-item-list-item`.

This is the patch for compatibility,

Have a nice day,